### PR TITLE
Add method `GetAllLinks`

### DIFF
--- a/ContentValidation/ExtraLabelValidation.cs
+++ b/ContentValidation/ExtraLabelValidation.cs
@@ -62,6 +62,10 @@ public class ExtraLabelValidation : IValidation
             int count = 0;
             while ((index = text.IndexOf(label, index)) != -1)
             {
+                if(text.IndexOf("<true", index) == index){
+                    index += 5;
+                    continue;
+                }
                 count++;
                 sum++;
                 index += label.Length;

--- a/ContentValidation/GarbledTextValidation.cs
+++ b/ContentValidation/GarbledTextValidation.cs
@@ -29,6 +29,9 @@ namespace UtilityLibraries
 
             foreach (Match match in matches)
             {
+                if(match.Value == ":mm:" || match.Value == ":05:"){
+                    continue;
+                }
                 errorList.Add(match.Value);
             }
 

--- a/ContentValidation/UnnecessarySymbolsValidation.cs
+++ b/ContentValidation/UnnecessarySymbolsValidation.cs
@@ -54,17 +54,30 @@ public class UnnecessarySymbolsValidation : IValidation
 
         foreach (var tableContent in tableContents)
         {
-            var tagMatches = Regex.Matches(tableContent, @"<\/\w+>\s*&gt;\s*<\/\w+>|~");
-            foreach (Match match in tagMatches)
+            var tagMatches1 = Regex.Matches(tableContent, @"<\/\w+>\s*&gt;\s*<\/\w+>");
+            var tagMatches2 = Regex.Matches(tableContent, @"<(?!\/?p\b)[^>]*>.*?~.*?<\/[^>]+>");
+            foreach (Match match in tagMatches1)
             {
                 var value = match.Value;
-                if (!value.Equals("~"))
+                if (!value.Equals(""))
                 {
                     value = ">";
                 }
                 valueSet.Add($"{value}");
                 errorList.Add($"Table no.{index + 1} contains unnecessary symbol: {value}");
             }
+
+            foreach (Match match in tagMatches2)
+            {
+                var value = match.Value;
+                if (!value.Equals(""))
+                {
+                    value = "~";
+                }
+                valueSet.Add($"{value}");
+                errorList.Add($"Table no.{index + 1} contains unnecessary symbol: {value}");
+            }
+
             index++;
         }
 

--- a/DataSource/Program.cs
+++ b/DataSource/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
 namespace DataSource
@@ -20,6 +21,9 @@ namespace DataSource
             string? service = config["ServiceName"];
             string? package = config["PackageName"];
 
+            //test for use,48 links and 3 basic links   total links: 51
+            //string? package = "azure-cognitiveservices-search-websearch";
+
             // Fetch all need to be validated pages in a service/packages.
             List<string> pages = new List<string>();
 
@@ -31,9 +35,9 @@ namespace DataSource
 
             pages.Add(apiRefDocPage);
 
-            List<string> subPages = GetAllSubPages(apiRefDocPage, package);
+            //List<string> subPages = GetAllSubPages(apiRefDocPage, package);
 
-            pages.AddRange(subPages);
+            GetAllLinks(apiRefDocPage, package, pages);
 
             ExportData(pages);
 
@@ -56,51 +60,77 @@ namespace DataSource
             return $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/{packageName?.ToLower().Replace("-",".")}?{PYTHON_SDK_API_URL_SUFFIX}";
         }
 
-        static List<string> GetAllSubPages(string apiRefDocPage, string? packageName)
-        {
-            List<string> subPages = new List<string>();
-
-            List<string> pkgsAndClassesPages = GetPkgsAndClassesPages(apiRefDocPage);
-
-            foreach (var page in pkgsAndClassesPages)
-            {
-                string pkgAndClassesPage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + page;
-                subPages.Add(pkgAndClassesPage);
-                List<string> subPackagesPages = GetSubPackagesPages(pkgAndClassesPage);
-
-                foreach (var subPage in subPackagesPages) { 
-                    string subPackagePage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subPage;
-                    subPages.Add(subPackagePage);
-                    List<string> subSubPackagesPages = GetSubPackagesPages(subPackagePage);
-
-                    foreach (var subSubPage in subSubPackagesPages) { 
-                        subPages.Add($"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subSubPage);
-                    }
-                }
-            }
-
-            return subPages;
-        }
-        static List<string> GetPkgsAndClassesPages(string apiRefDocPage)
+        static void GetAllLinks(string apiRefDocPage, string? packageName, List<string> links)
         {
             HtmlWeb web = new HtmlWeb();
             var doc = web.Load(apiRefDocPage);
-            var aNodes = doc.DocumentNode.SelectNodes("//td/a");
-            return aNodes.Select(pages => pages.Attributes["href"].Value).ToList();
+            var h1Node = doc.DocumentNode.SelectSingleNode("//h1")?.InnerText;
+
+            if (!string.IsNullOrEmpty(h1Node) && h1Node.Contains("Package"))
+            {
+                var aNodes = doc.DocumentNode.SelectNodes("//td/a");
+                if (aNodes != null)
+                {
+                    foreach (var node in aNodes)
+                    {
+                        string href = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + node.Attributes["href"].Value;
+
+                        if (!links.Contains(href))
+                        {
+                            links.Add(href);
+
+                            GetAllLinks(href, packageName, links);
+                        }
+                    }
+                }
+            }
         }
 
-        static List<string> GetSubPackagesPages(string subPage)
-        {
-            HtmlWeb web = new HtmlWeb();
-            var doc = web.Load(subPage);
-            List<string> subPackagesPages = new List<string>();
-            var h1Node = doc.DocumentNode.SelectSingleNode("//h1").InnerText;
-            if (h1Node.Contains("Package")) {
-                var aNodes = doc.DocumentNode.SelectNodes("//td/a");
-                subPackagesPages.AddRange(aNodes.Select(pages => pages.Attributes["href"].Value).ToList());
-            }
-            return subPackagesPages;
-        }
+        //static List<string> GetAllSubPages(string apiRefDocPage, string? packageName)
+        //{
+        //    List<string> subPages = new List<string>();
+
+        //    List<string> pkgsAndClassesPages = GetPkgsAndClassesPages(apiRefDocPage);
+
+        //    foreach (var page in pkgsAndClassesPages)
+        //    {
+        //        string pkgAndClassesPage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + page;
+        //        subPages.Add(pkgAndClassesPage);
+        //        List<string> subPackagesPages = GetSubPackagesPages(pkgAndClassesPage);
+
+        //        foreach (var subPage in subPackagesPages) { 
+        //            string subPackagePage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subPage;
+        //            subPages.Add(subPackagePage);
+        //            List<string> subSubPackagesPages = GetSubPackagesPages(subPackagePage);
+
+        //            foreach (var subSubPage in subSubPackagesPages) { 
+        //                subPages.Add($"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subSubPage);
+        //            }
+        //        }
+        //    }
+
+        //    return subPages;
+        //}
+        //static List<string> GetPkgsAndClassesPages(string apiRefDocPage)
+        //{
+        //    HtmlWeb web = new HtmlWeb();
+        //    var doc = web.Load(apiRefDocPage);
+        //    var aNodes = doc.DocumentNode.SelectNodes("//td/a");
+        //    return aNodes.Select(pages => pages.Attributes["href"].Value).ToList();
+        //}
+
+        //static List<string> GetSubPackagesPages(string subPage)
+        //{
+        //    HtmlWeb web = new HtmlWeb();
+        //    var doc = web.Load(subPage);
+        //    List<string> subPackagesPages = new List<string>();
+        //    var h1Node = doc.DocumentNode.SelectSingleNode("//h1").InnerText;
+        //    if (h1Node.Contains("Package")) {
+        //        var aNodes = doc.DocumentNode.SelectNodes("//td/a");
+        //        subPackagesPages.AddRange(aNodes.Select(pages => pages.Attributes["href"].Value).ToList());
+        //    }
+        //    return subPackagesPages;
+        //}
 
         static void ExportData(List<string> pages)
         {


### PR DESCRIPTION
1.
**Method:**
DataSource: Program.cs - Add method `GetAllLinks(string apiRefDocPage, string? packageName, List<string> links)`

**Input parameters:**

- `apiRefDocPage` (string): URL of the current page.
- `packageName` (string?): the package name, used to splice the full link path.
- `links` (List<string>): shared list storing all extracted links.

**Output:**
No return value(void), the result is stored in the input links list, containing the full URL of the current page and all subpages.

**Design:**

- Load page: Use `HtmlAgilityPack` to load the incoming URL page.
- Page Validation: Checks if the `h1` node exists and contains the “Package” keyword.
- Find Links: Locate all <a> tag nodes matching `//td/a` and extract their `href` attributes.
- Generate full link: Construct the full link path using `PYTHON_SDK_API_URL_PREFIX` and `packageName`.
- De-duplication check: check if the link already exists in the links list, and add it if it doesn't.
- Recursive processing: Call `GetAllLinks` method recursively for each new link.
- Termination condition: the recursion terminates when there are no valid sublinks in the page or when all links have been visited.

**Result:**
Test packageName: [azure-cognitiveservices-search-websearch](https://learn.microsoft.com/en-us/python/api/azure-cognitiveservices-search-websearch/azure.cognitiveservices.search.websearch?view=azure-python)
![image](https://github.com/user-attachments/assets/81a01aa4-23b2-4bc7-b43f-7b2b269fe649)
Notes: The total number of links is 51, acquired links are 48

@zedy-wj  and @v-xuto for notification.