### PR TITLE
Add method `GetAllLinks`

### DIFF
--- a/DataSource/Program.cs
+++ b/DataSource/Program.cs
@@ -32,8 +32,7 @@ namespace DataSource
 
             pages.Add(apiRefDocPage);
 
-            //List<string> subPages = GetAllSubPages(apiRefDocPage, package);
-
+            //Get all the links in the package that need to be tested.
             GetAllLinks(apiRefDocPage, package, pages);
 
             ExportData(pages);
@@ -63,6 +62,7 @@ namespace DataSource
             var doc = web.Load(apiRefDocPage);
             var h1Node = doc.DocumentNode.SelectSingleNode("//h1")?.InnerText;
 
+            //The recursion terminates when there are no valid sublinks in the page or when all Package links have been visited.
             if (!string.IsNullOrEmpty(h1Node) && h1Node.Contains("Package"))
             {
                 var aNodes = doc.DocumentNode.SelectNodes("//td/a");
@@ -76,58 +76,13 @@ namespace DataSource
                         {
                             links.Add(href);
 
+                            //Call GetAllLinks method recursively for each new link.
                             GetAllLinks(href, packageName, links);
                         }
                     }
                 }
             }
         }
-
-        //static List<string> GetAllSubPages(string apiRefDocPage, string? packageName)
-        //{
-        //    List<string> subPages = new List<string>();
-
-        //    List<string> pkgsAndClassesPages = GetPkgsAndClassesPages(apiRefDocPage);
-
-        //    foreach (var page in pkgsAndClassesPages)
-        //    {
-        //        string pkgAndClassesPage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + page;
-        //        subPages.Add(pkgAndClassesPage);
-        //        List<string> subPackagesPages = GetSubPackagesPages(pkgAndClassesPage);
-
-        //        foreach (var subPage in subPackagesPages) { 
-        //            string subPackagePage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subPage;
-        //            subPages.Add(subPackagePage);
-        //            List<string> subSubPackagesPages = GetSubPackagesPages(subPackagePage);
-
-        //            foreach (var subSubPage in subSubPackagesPages) { 
-        //                subPages.Add($"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subSubPage);
-        //            }
-        //        }
-        //    }
-
-        //    return subPages;
-        //}
-        //static List<string> GetPkgsAndClassesPages(string apiRefDocPage)
-        //{
-        //    HtmlWeb web = new HtmlWeb();
-        //    var doc = web.Load(apiRefDocPage);
-        //    var aNodes = doc.DocumentNode.SelectNodes("//td/a");
-        //    return aNodes.Select(pages => pages.Attributes["href"].Value).ToList();
-        //}
-
-        //static List<string> GetSubPackagesPages(string subPage)
-        //{
-        //    HtmlWeb web = new HtmlWeb();
-        //    var doc = web.Load(subPage);
-        //    List<string> subPackagesPages = new List<string>();
-        //    var h1Node = doc.DocumentNode.SelectSingleNode("//h1").InnerText;
-        //    if (h1Node.Contains("Package")) {
-        //        var aNodes = doc.DocumentNode.SelectNodes("//td/a");
-        //        subPackagesPages.AddRange(aNodes.Select(pages => pages.Attributes["href"].Value).ToList());
-        //    }
-        //    return subPackagesPages;
-        //}
 
         static void ExportData(List<string> pages)
         {

--- a/DataSource/Program.cs
+++ b/DataSource/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
 namespace DataSource
@@ -20,6 +21,9 @@ namespace DataSource
             string? service = config["ServiceName"];
             string? package = config["PackageName"];
 
+            //test for use,48 links and 3 basic links   total links: 51
+            //string? package = "azure-cognitiveservices-search-websearch";
+
             // Fetch all need to be validated pages in a service/packages.
             List<string> pages = new List<string>();
 
@@ -31,9 +35,9 @@ namespace DataSource
 
             pages.Add(apiRefDocPage);
 
-            List<string> subPages = GetAllSubPages(apiRefDocPage, package);
+            //List<string> subPages = GetAllSubPages(apiRefDocPage, package);
 
-            pages.AddRange(subPages);
+            GetAllLinks(apiRefDocPage, package, pages);
 
             ExportData(pages);
 
@@ -56,51 +60,77 @@ namespace DataSource
             return $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/{packageName?.ToLower().Replace("-",".")}?{PYTHON_SDK_API_URL_SUFFIX}";
         }
 
-        static List<string> GetAllSubPages(string apiRefDocPage, string? packageName)
-        {
-            List<string> subPages = new List<string>();
-
-            List<string> pkgsAndClassesPages = GetPkgsAndClassesPages(apiRefDocPage);
-
-            foreach (var page in pkgsAndClassesPages)
-            {
-                string pkgAndClassesPage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + page;
-                subPages.Add(pkgAndClassesPage);
-                List<string> subPackagesPages = GetSubPackagesPages(pkgAndClassesPage);
-
-                foreach (var subPage in subPackagesPages) { 
-                    string subPackagePage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subPage;
-                    subPages.Add(subPackagePage);
-                    List<string> subSubPackagesPages = GetSubPackagesPages(subPackagePage);
-
-                    foreach (var subSubPage in subSubPackagesPages) { 
-                        subPages.Add($"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subSubPage);
-                    }
-                }
-            }
-
-            return subPages;
-        }
-        static List<string> GetPkgsAndClassesPages(string apiRefDocPage)
+        static void GetAllLinks(string apiRefDocPage, string? packageName, List<string> links)
         {
             HtmlWeb web = new HtmlWeb();
             var doc = web.Load(apiRefDocPage);
-            var aNodes = doc.DocumentNode.SelectNodes("//td/a");
-            return aNodes.Select(pages => pages.Attributes["href"].Value).ToList();
+            var h1Node = doc.DocumentNode.SelectSingleNode("//h1")?.InnerText;
+
+            if (!string.IsNullOrEmpty(h1Node) && h1Node.Contains("Package"))
+            {
+                var aNodes = doc.DocumentNode.SelectNodes("//td/a");
+                if (aNodes != null)
+                {
+                    foreach (var node in aNodes)
+                    {
+                        string href = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + node.Attributes["href"].Value;
+
+                        if (!links.Contains(href))
+                        {
+                            links.Add(href);
+
+                            GetAllLinks(href, packageName, links);
+                        }
+                    }
+                }
+            }
         }
 
-        static List<string> GetSubPackagesPages(string subPage)
-        {
-            HtmlWeb web = new HtmlWeb();
-            var doc = web.Load(subPage);
-            List<string> subPackagesPages = new List<string>();
-            var h1Node = doc.DocumentNode.SelectSingleNode("//h1").InnerText;
-            if (h1Node.Contains("Package")) {
-                var aNodes = doc.DocumentNode.SelectNodes("//td/a");
-                subPackagesPages.AddRange(aNodes.Select(pages => pages.Attributes["href"].Value).ToList());
-            }
-            return subPackagesPages;
-        }
+        //static List<string> GetAllSubPages(string apiRefDocPage, string? packageName)
+        //{
+        //    List<string> subPages = new List<string>();
+
+        //    List<string> pkgsAndClassesPages = GetPkgsAndClassesPages(apiRefDocPage);
+
+        //    foreach (var page in pkgsAndClassesPages)
+        //    {
+        //        string pkgAndClassesPage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + page;
+        //        subPages.Add(pkgAndClassesPage);
+        //        List<string> subPackagesPages = GetSubPackagesPages(pkgAndClassesPage);
+
+        //        foreach (var subPage in subPackagesPages) { 
+        //            string subPackagePage = $"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subPage;
+        //            subPages.Add(subPackagePage);
+        //            List<string> subSubPackagesPages = GetSubPackagesPages(subPackagePage);
+
+        //            foreach (var subSubPage in subSubPackagesPages) { 
+        //                subPages.Add($"{PYTHON_SDK_API_URL_PREFIX}/{packageName}/" + subSubPage);
+        //            }
+        //        }
+        //    }
+
+        //    return subPages;
+        //}
+        //static List<string> GetPkgsAndClassesPages(string apiRefDocPage)
+        //{
+        //    HtmlWeb web = new HtmlWeb();
+        //    var doc = web.Load(apiRefDocPage);
+        //    var aNodes = doc.DocumentNode.SelectNodes("//td/a");
+        //    return aNodes.Select(pages => pages.Attributes["href"].Value).ToList();
+        //}
+
+        //static List<string> GetSubPackagesPages(string subPage)
+        //{
+        //    HtmlWeb web = new HtmlWeb();
+        //    var doc = web.Load(subPage);
+        //    List<string> subPackagesPages = new List<string>();
+        //    var h1Node = doc.DocumentNode.SelectSingleNode("//h1").InnerText;
+        //    if (h1Node.Contains("Package")) {
+        //        var aNodes = doc.DocumentNode.SelectNodes("//td/a");
+        //        subPackagesPages.AddRange(aNodes.Select(pages => pages.Attributes["href"].Value).ToList());
+        //    }
+        //    return subPackagesPages;
+        //}
 
         static void ExportData(List<string> pages)
         {

--- a/DataSource/Program.cs
+++ b/DataSource/Program.cs
@@ -21,9 +21,6 @@ namespace DataSource
             string? service = config["ServiceName"];
             string? package = config["PackageName"];
 
-            //test for use,48 links and 3 basic links   total links: 51
-            //string? package = "azure-cognitiveservices-search-websearch";
-
             // Fetch all need to be validated pages in a service/packages.
             List<string> pages = new List<string>();
 


### PR DESCRIPTION
1.
**Method:**
DataSource: Program.cs - Add method `GetAllLinks(string apiRefDocPage, string? packageName, List<string> links)`

**Input parameters:**

- `apiRefDocPage` (string): URL of the current page.
- `packageName` (string?): the package name, used to splice the full link path.
- `links` (List<string>): shared list storing all extracted links.

**Output:**
No return value(void), the result is stored in the input links list, containing the full URL of the current page and all subpages.

**Design:**

- Load page: Use `HtmlAgilityPack` to load the incoming URL page.
- Page Validation: Checks if the `h1` node exists and contains the “Package” keyword.
- Find Links: Locate all <a> tag nodes matching `//td/a` and extract their `href` attributes.
- Generate full link: Construct the full link path using `PYTHON_SDK_API_URL_PREFIX` and `packageName`.
- De-duplication check: check if the link already exists in the links list, and add it if it doesn't.
- Recursive processing: Call `GetAllLinks` method recursively for each new link.
- Termination condition: the recursion terminates when there are no valid sublinks in the page or when all links have been visited.

@zedy-wj  and @v-xuto for notification.